### PR TITLE
Fix formatting issues with newer clang-format versions

### DIFF
--- a/src/lib/calculate.cpp
+++ b/src/lib/calculate.cpp
@@ -1,5 +1,5 @@
 #include "calculate.hpp"
 
-auto Calculate::sum(const double &a, const double &b) -> double {
+auto Calculate::sum(const double& a, const double& b) -> double {
     return a + b;
 }

--- a/src/lib/calculate.hpp
+++ b/src/lib/calculate.hpp
@@ -10,7 +10,7 @@ class Calculate {
      * @param b The second floating point number.
      * @return The sum of the two floating point numbers.
      */
-    static auto sum(const double &a, const double &b) -> double;
+    static auto sum(const double& a, const double& b) -> double;
 
     // TODO: add more functions here
 };


### PR DESCRIPTION
When using clang-format v22.1.5 formatting issues were reported. This MR fixes the wrongly formatted files.