### PR TITLE
Renovate: make timestamp optional

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "default:rebaseStalePrs"
   ],
   "minimumReleaseAge": "14 days",
+  "minimumReleaseAgeBehaviour": "timestamp-optional",
   "prCreation": "not-pending",
   "git-submodules": {
     "enabled": true


### PR DESCRIPTION
Update Renovate configuration to treat 'no timestamp available' as 'stable' instead of blocking the update forever:

https://docs.renovatebot.com/configuration-options/#minimumreleaseagebehaviour